### PR TITLE
class based CombinedFetch

### DIFF
--- a/lib/sidekiq/priority_queue/combined_fetch.rb
+++ b/lib/sidekiq/priority_queue/combined_fetch.rb
@@ -3,17 +3,9 @@
 module Sidekiq
   module PriorityQueue
     class CombinedFetch
-      def initialize(&block)
-        @fetches = []
-        yield self
-      end
 
-      def add(fetch)
-        @fetches << fetch
-      end
-      
-      def new(options)
-        self
+      def initialize(options)
+        @fetches = @@fetches.map{ |f| f.new(options) }
       end
 
       def retrieve_work
@@ -21,6 +13,16 @@ module Sidekiq
           work = fetch.retrieve_work
           return work if work
         end
+      end
+
+      def self.configure(&block)
+        @@fetches = []
+        yield self
+        self
+      end
+
+      def self.add(fetch)
+        @@fetches << fetch
       end
     end
   end

--- a/test/test_combined_fetch.rb
+++ b/test/test_combined_fetch.rb
@@ -22,10 +22,12 @@ class TestFetcher < Sidekiq::Test
     end
 
     it 'retrieves from both normal and priority queues' do
-      fetch = Sidekiq::PriorityQueue::CombinedFetch.new do |fetches|
-        fetches.add Sidekiq::BasicFetch.new(:queues => ['foo'])
-        fetches.add Sidekiq::PriorityQueue::Fetch.new(:queues => ['foo'])
+      fetch = Sidekiq::PriorityQueue::CombinedFetch.configure do |fetches|
+        fetches.add Sidekiq::BasicFetch
+        fetches.add Sidekiq::PriorityQueue::Fetch
       end
+
+      fetch = fetch.new(:queues => ['foo'])
 
       uow = fetch.retrieve_work
       refute_nil uow


### PR DESCRIPTION
Sidekiq actually expects config['fetch'] to be a class it can make an instance of, passing options as an argument, rather than an already instantiated and class.