### PR TITLE
Sidekiq Client Duplicates Jobs [ch6303]

### DIFF
--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -14,12 +14,13 @@ class TestClient < Sidekiq::Test
       assert_equal 1, Sidekiq::Queue.new().size
     end
 
-    it 'pushes to a priority queue' do
+    it 'pushes to a priority queue and not a normal queue' do
       Sidekiq.redis {|c| c.flushdb }
-      assert Worker.set(priority: 1).perform_async(1)
+      assert Worker.set(priority: 0).perform_async(1)
       assert_equal 1, Sidekiq::PriorityQueue::Queue.new().size
-      job_count = Sidekiq.redis {|c| c.zcount('priority-queue:default', 1, 1) }
+      job_count = Sidekiq.redis {|c| c.zcount('priority-queue:default', 0, 0) }
       assert_equal 1, job_count
+      assert_equal 0, Sidekiq::Queue.new().size
     end
 
     class PrioritizedWorker


### PR DESCRIPTION
Unfortunately the Sidekiq documentation here: https://github.com/mperham/sidekiq/wiki/Middleware is not quite correct. You can't actually prevent Sidekiq from pushing a job by simply not yielding. You have to return something false-ish, which breaks the API which should return a job ID for a successful push.

I think it's possible to put the call to continue pushing inside the block given to the middleware, so not yielding would actually work, but it's a bigger change than this.