### PR TITLE
Priority Queue List Performance [ch6330]

### DIFF
--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -8,6 +8,7 @@ class TestApi < Sidekiq::Test
       Sidekiq.redis = { :url => REDIS_URL }
       Sidekiq.redis do |conn|
         conn.flushdb
+        conn.sadd('priority-queues', 'priority-queue:foo')
         conn.zadd('priority-queue:foo', 0, 'blah')
         conn.zadd("priority-queue-counts:foo", 1, 'blah')
       end

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -25,8 +25,9 @@ class TestWeb < Sidekiq::Test
 
     before do
       Sidekiq.redis = { :url => REDIS_URL }
-      Sidekiq.redis do |conn| 
+      Sidekiq.redis do |conn|
         conn.flushdb
+        conn.sadd('priority-queues', 'priority-queue:default')
         conn.zadd('priority-queue:default', 0, job.to_json)
         conn.zadd("priority-queue-counts:default", 2, job_2['subqueue'])
       end


### PR DESCRIPTION
Basically using scanning for this is far too slow. You need to store the queues as you push into them in a set for lookup later.