### PR TITLE
Fix Loofah vulnerability: CVE-2018-16468

### DIFF
--- a/myapp/Gemfile.lock
+++ b/myapp/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -135,4 +135,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.3
+   1.17.1


### PR DESCRIPTION
Not really needed, as `myapp` is solely used for specs.

