### PR TITLE
Use instance of fetch algorithm instead of class [ch25001]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,4 @@ before_install:
   - gem update bundler
 
 rvm:
-  - 2.4
   - 2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    sidekiq-priority_queue (0.1.0)
+    sidekiq-priority_queue (1.0.0)
       sidekiq (>= 6)
 
 GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.1.3)
-    coderay (1.1.2)
+    coderay (1.1.3)
     connection_pool (2.2.3)
-    docile (1.3.2)
+    docile (1.3.4)
     method_source (1.0.0)
-    minitest (5.14.1)
+    minitest (5.14.3)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -22,16 +22,18 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (13.0.1)
+    rake (13.0.3)
     redis (4.2.5)
     sidekiq (6.1.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    simplecov (0.18.5)
+    simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sidekiq-priority_queue (0.1.0)
-      sidekiq (>= 4)
+      sidekiq (>= 6)
 
 GEM
   remote: https://rubygems.org/
@@ -20,17 +20,14 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.1)
-    redis (4.1.4)
-    sidekiq (5.2.9)
-      connection_pool (~> 2.2, >= 2.2.2)
+    redis (4.2.5)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 4.2)
+      redis (>= 4.2.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/sidekiq/priority_queue/fetch.rb
+++ b/lib/sidekiq/priority_queue/fetch.rb
@@ -61,7 +61,7 @@ module Sidekiq
         end
       end
 
-      def self.bulk_requeue(inprogress, options)
+      def bulk_requeue(inprogress, options)
         return if inprogress.empty?
 
         Sidekiq.logger.debug { "Re-queueing terminated jobs" }

--- a/lib/sidekiq/priority_queue/reliable_fetch.rb
+++ b/lib/sidekiq/priority_queue/reliable_fetch.rb
@@ -72,10 +72,10 @@ module Sidekiq
         end
       end
 
-      def self.bulk_requeue(_inprogress, options)
+      def bulk_requeue(_inprogress, options)
         Sidekiq.logger.debug { "Re-queueing terminated jobs" }
         process_index = options[:index] || ENV['PROCESS_INDEX']
-        requeue_wip_jobs(options[:queues], process_index)
+        self.class.requeue_wip_jobs(options[:queues], process_index)
       end
 
       def self.resume_wip_jobs(queues, process_index)
@@ -95,9 +95,9 @@ module Sidekiq
       private
 
       def self.reliable_fetch_active?(config)
-        return true if config.options[:fetch] == Sidekiq::PriorityQueue::ReliableFetch
-        return config.options[:fetch] == Sidekiq::PriorityQueue::CombinedFetch &&
-          config.options[:fetch].fetches.include?(Sidekiq::PriorityQueue::ReliableFetch)
+        return true if config.options[:fetch].is_a?(Sidekiq::PriorityQueue::ReliableFetch)
+        return config.options[:fetch].is_a?(Sidekiq::PriorityQueue::CombinedFetch) &&
+          config.options[:fetch].fetches.any? { |f| f.is_a?(Sidekiq::PriorityQueue::ReliableFetch) }
       end
 
       def self.requeue_wip_jobs(queues, index)

--- a/sidekiq-priority_queue.gemspec
+++ b/sidekiq-priority_queue.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|pkg)/}) }
   s.homepage    = 'https://github.com/chartmogul/sidekiq-priority_queue'
   s.license     = 'MIT'
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_dependency 'sidekiq', '>= 6'
   s.add_development_dependency 'minitest', '~> 5.10', '>= 5.10.1'

--- a/sidekiq-priority_queue.gemspec
+++ b/sidekiq-priority_queue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'sidekiq-priority_queue'
-  s.version     = '0.1.0'
+  s.version     = '1.0.0'
   s.date        = '2018-07-31'
   s.summary     = "Priority Queuing for Sidekiq"
   s.description = "An extension for Sidekiq allowing jobs in a single queue to be execued by a priority score rather than FIFO"
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'sidekiq', '>= 4'
+  s.add_dependency 'sidekiq', '>= 6'
   s.add_development_dependency 'minitest', '~> 5.10', '>= 5.10.1'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,7 +7,7 @@
 # frozen_string_literal: true
 $TESTING = true
 # disable minitest/parallel threads
-ENV["N"] = "0"
+ENV["MT_CPU"] = "0"
 
 if ENV["COVERAGE"]
   require 'simplecov'

--- a/test/test_combined_fetch.rb
+++ b/test/test_combined_fetch.rb
@@ -23,11 +23,9 @@ class TestFetcher < Sidekiq::Test
 
     it 'retrieves from both normal and priority queues' do
       fetch = Sidekiq::PriorityQueue::CombinedFetch.configure do |fetches|
-        fetches.add Sidekiq::BasicFetch
-        fetches.add Sidekiq::PriorityQueue::Fetch
+        fetches.add Sidekiq::BasicFetch.new(queues: ['foo'])
+        fetches.add Sidekiq::PriorityQueue::Fetch.new(queues: ['foo'])
       end
-
-      fetch = fetch.new(:queues => ['foo'])
 
       uow = fetch.retrieve_work
       refute_nil uow
@@ -42,8 +40,8 @@ class TestFetcher < Sidekiq::Test
 
     it 'bulk requeues all jobs only once' do
       fetch = Sidekiq::PriorityQueue::CombinedFetch.configure do |fetches|
-        fetches.add Sidekiq::BasicFetch
-        fetches.add Sidekiq::PriorityQueue::Fetch
+        fetches.add Sidekiq::BasicFetch.new(queues: ['foo'], index: 0)
+        fetches.add Sidekiq::PriorityQueue::Fetch.new(queues: ['foo'], index: 0)
       end
 
       q1 = Sidekiq::PriorityQueue::Queue.new('foo')

--- a/test/test_fetch.rb
+++ b/test/test_fetch.rb
@@ -46,7 +46,7 @@ class TestFetcher < Sidekiq::Test
       assert_equal 1, q1.size
       assert_equal 0, q2.size
       uow = Sidekiq::PriorityQueue::Fetch::UnitOfWork
-      Sidekiq::PriorityQueue::Fetch.bulk_requeue(
+      Sidekiq::PriorityQueue::Fetch.new(queues: []).bulk_requeue(
         [ uow.new('priority-queue:foo', 'bob'), uow.new('fuzzy:queue:foo', 'bar') ],
         queues: []
       )

--- a/test/test_reliable_fetch.rb
+++ b/test/test_reliable_fetch.rb
@@ -64,7 +64,7 @@ class TestFetcher < Sidekiq::Test
         conn.sadd("priority-queue:foo_#{Socket.gethostname}_0", 'bob')
       end
 
-      Sidekiq::PriorityQueue::ReliableFetch.bulk_requeue(
+      Sidekiq::PriorityQueue::ReliableFetch.new(queues: ['foo'], index: 0).bulk_requeue(
         [ uow.new('priority-queue:foo', 'bob'), uow.new('fuzzy:queue:foo', 'bar') ],
         { queues: ['foo'], index: 0 }
       )


### PR DESCRIPTION
This PR makes some breaking changes to support Sidekiq 6, 

In sidekiq 6 they have stopped expecting a fetch algorthim class and instead require an instance which is then directly used. Our replication of `ReliableFetch` was using a mix of instance methods as well as some class methods which sidekiq 5 supports but sidekiq 6 doesn't. As a bonus we removed some code smells which could hamper thread-safety 🕺🏼 🚀 

I also had to upgrade the minimum required sidekiq version to run tests against Sidekiq 6, which in turn highlighted the issue with minimum ruby version. 

After merge, I'll tag this as v1.0.0.