### PR TITLE
Add size of each subqueue from biggest to smallest

### DIFF
--- a/lib/sidekiq/priority_queue/api.rb
+++ b/lib/sidekiq/priority_queue/api.rb
@@ -48,6 +48,8 @@ module Sidekiq
 
     end
 
+    SubqueueCount = Struct.new(:name, :size)
+
     class Job < Sidekiq::Job
 
       attr_reader :priority

--- a/lib/sidekiq/priority_queue/web/views/priority_queue.erb
+++ b/lib/sidekiq/priority_queue/web/views/priority_queue.erb
@@ -10,6 +10,32 @@
     <%= erb :_paging, locals: { url: "#{root_path}priority_queues/#{CGI.escape(@name)}" } %>
   </div>
 </header>
+<div class="row">
+  <div class="col-sm-12">
+    <h3>Biggest subqueues</h3>
+
+    <summary>
+      <details>
+        <div class="table_container">
+          <table class="table table-hover table-bordered table-striped">
+            <thead>
+              <th>Subqueue name</th>
+              <th>Subqueue size</th>
+            </thead>
+            <% @subqueue_counts.each do |subqueue_count| %>
+              <tr>
+                <td><%= subqueue_count.name %></td>
+                <td><%= subqueue_count.size %></td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
+      </details>
+    </summary>
+
+  </div>
+</div>
+<hr />
 <div class="table_container">
   <table class="queue table table-hover table-bordered table-striped">
     <thead>


### PR DESCRIPTION
## Description

This adds size of each subqueue for each priority queue user is viewing. This should increase visibility into which subqueue is the biggest. By default it won't show when entering page by using `summary` HTML tag so it won't bloat right away if it's not needed.

## Screenshots

![image](https://user-images.githubusercontent.com/5666244/111802276-16144600-88ce-11eb-909a-dbc045728ec8.png)

## To do after merging

- [ ] - Tag newest commit with value `1.0.1`