### PR TITLE
Make compatible with sidekiq >= 6.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     sidekiq-priority_queue (1.0.2)
-      sidekiq (>= 6)
+      sidekiq (>= 6.2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.1.3)
     coderay (1.1.3)
-    connection_pool (2.2.3)
+    connection_pool (2.2.5)
     docile (1.3.4)
     method_source (1.0.0)
     minitest (5.14.3)
@@ -23,8 +23,8 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.3)
-    redis (4.2.5)
-    sidekiq (6.1.3)
+    redis (4.4.0)
+    sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sidekiq-priority_queue (1.0.2)
+    sidekiq-priority_queue (1.0.3)
       sidekiq (>= 6.2.2)
 
 GEM

--- a/lib/sidekiq/priority_queue/api.rb
+++ b/lib/sidekiq/priority_queue/api.rb
@@ -50,7 +50,7 @@ module Sidekiq
 
     SubqueueCount = Struct.new(:name, :size)
 
-    class Job < Sidekiq::Job
+    class Job < Sidekiq::JobRecord
 
       attr_reader :priority
       attr_reader :subqueue

--- a/sidekiq-priority_queue.gemspec
+++ b/sidekiq-priority_queue.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = '>= 2.5.0'
 
-  s.add_dependency 'sidekiq', '>= 6'
+  s.add_dependency 'sidekiq', '>= 6.2.2'
   s.add_development_dependency 'minitest', '~> 5.10', '>= 5.10.1'
 end

--- a/sidekiq-priority_queue.gemspec
+++ b/sidekiq-priority_queue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'sidekiq-priority_queue'
-  s.version     = '1.0.2'
+  s.version     = '1.0.3'
   s.date        = '2018-07-31'
   s.summary     = "Priority Queuing for Sidekiq"
   s.description = "An extension for Sidekiq allowing jobs in a single queue to be executed by a priority score rather than FIFO"


### PR DESCRIPTION
This PR fixes a breaking change in Sidekiq `6.2.2` where the internal class `Sidekiq::Job` was renamed to `Sidekiq::JobRecord`. 
