### PR TITLE
Implement orphan check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,6 @@ jobs:
     name: Run tests
     outputs:
       job-status: ${{ job.status }}
-    strategy:
-      matrix:
-        ruby-version: [ '2.7', '3.0' ]
     runs-on: ubuntu-18.04
     timeout-minutes: 10
     services:
@@ -25,7 +22,7 @@ jobs:
       - name: Set up correct version of Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby-version }}
+          ruby-version: 2.7
       - name: Install dependencies via Bundler
         run: bundle install --jobs 4 --retry 3
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ jobs:
     name: Run tests
     outputs:
       job-status: ${{ job.status }}
+    strategy:
+      matrix:
+        ruby-version: [ '2.7', '3.0' ]
     runs-on: ubuntu-18.04
     timeout-minutes: 10
     services:
@@ -22,7 +25,7 @@ jobs:
       - name: Set up correct version of Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies via Bundler
         run: bundle install --jobs 4 --retry 3
       - name: Run tests

--- a/lib/sidekiq/priority_queue/reliable_fetch.rb
+++ b/lib/sidekiq/priority_queue/reliable_fetch.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'sidekiq'
 require 'sidekiq/util'
 
@@ -6,6 +7,8 @@ module Sidekiq
   module PriorityQueue
     class ReliableFetch
       include Sidekiq::Util
+
+      SUPER_PROCESSES_REGISTRY_KEY = 'super_processes_priority'
 
       UnitOfWork = Struct.new(:queue, :job, :wip_queue) do
         def acknowledge
@@ -37,6 +40,7 @@ module Sidekiq
       end
 
       def initialize(options)
+        @options = options
         @strictly_ordered_queues = !!options[:strict]
         @queues = options[:queues].map { |q| "priority-queue:#{q}" }
         @queues = @queues.uniq if @strictly_ordered_queues
@@ -48,6 +52,7 @@ module Sidekiq
         Sidekiq.on(:startup) do
           cleanup_the_dead
           register_myself
+          check
         end
         Sidekiq.on(:shutdown) do
           @done = true
@@ -61,8 +66,8 @@ module Sidekiq
         return nil if @done
 
         work = @queues.detect do |q|
-          job = zpopmin_sadd(q, wip_queue(q));
-          break [q,job] if job
+          job = zpopmin_sadd(q, wip_queue(q))
+          break [q, job] if job
         end
         UnitOfWork.new(*work, wip_queue(work.first)) if work
       end
@@ -72,9 +77,9 @@ module Sidekiq
       end
 
       def zpopmin_sadd(queue, wip_queue)
-        Sidekiq.redis do |con|
-          @script_sha ||= con.script(:load, Sidekiq::PriorityQueue::Scripts::ZPOPMIN_SADD)
-          con.evalsha(@script_sha, [queue, wip_queue])
+        Sidekiq.redis do |conn|
+          @script_sha ||= conn.script(:load, Sidekiq::PriorityQueue::Scripts::ZPOPMIN_SADD)
+          conn.evalsha(@script_sha, [queue, wip_queue])
         end
       end
 
@@ -92,18 +97,80 @@ module Sidekiq
 
       # Below method is called when we close sidekiq process gracefully
       def bulk_requeue(_inprogress, _options)
-        Sidekiq.logger.debug { "Priority ReliableFetch: Re-queueing terminated jobs" }
+        Sidekiq.logger.debug { 'Priority ReliableFetch: Re-queueing terminated jobs' }
         requeue_wip_jobs
         unregister_super_process
       end
 
       private
 
+      def check
+        check_for_orphans if orphan_check?
+      rescue StandardError => e
+        # orphan check is best effort, we don't want Redis downtime to
+        # break Sidekiq
+        Sidekiq.logger.warn { "Priority ReliableFetch: Failed to do orphan check: #{e.message}" }
+      end
+
+      def orphan_check?
+        delay = @options.fetch(:super_fetch_orphan_check, 3600).to_i
+        return false if delay.zero?
+
+        Sidekiq.redis do |conn|
+          conn.set('priority_reliable_fetch_orphan_check', Time.now.to_f, ex: delay, nx: true)
+        end
+      end
+
+      # This method is extra paranoid verification to check Redis for any possible
+      # orphaned queues with jobs. If we change queue names and lose jobs in the meantime,
+      # this will find old queues with jobs and rescue them.
+      def check_for_orphans
+        orphans_count = 0
+        queues_count = 0
+        orphan_queues = Set.new
+        Sidekiq.redis do |conn|
+          ids = conn.smembers(SUPER_PROCESSES_REGISTRY_KEY)
+          Sidekiq.logger.debug("Priority ReliableFetch found #{ids.size} super processes")
+
+          conn.scan_each(match: 'queue:spriorityq|*', count: 100) do |wip_queue|
+            queues_count += 1
+            _, id, original_priority_queue_name = wip_queue.split('|')
+            next if ids.include?(id)
+
+            # Race condition in pulling super_processes and checking queue liveness.
+            # Need to verify in Redis.
+            unless conn.sismember(SUPER_PROCESSES_REGISTRY_KEY, id)
+              orphan_queues << original_priority_queue_name
+              queue_jobs_count = 0
+              loop do
+                break if conn.scard(wip_queue).zero?
+
+                # Here we should wrap below two operations in Lua script
+                item = conn.spop(wip_queue)
+                conn.zadd(original_priority_queue_name, 0, item)
+                orphans_count += 1
+                queue_jobs_count += 1
+              end
+              if queue_jobs_count.positive?
+                Sidekiq::Pro.metrics.increment('jobs.recovered.fetch', by: queue_jobs_count, tags: ["queue:#{original_priority_queue_name}"])
+              end
+            end
+          end
+        end
+
+        if orphans_count.positive?
+          Sidekiq.logger.warn { "Priority ReliableFetch recovered #{orphans_count} orphaned jobs in queues: #{orphan_queues.to_a.inspect}" }
+        elsif queues_count.positive?
+          Sidekiq.logger.info { "Priority ReliableFetch found #{queues_count} working queues with no orphaned jobs" }
+        end
+        orphans_count
+      end
+
       # Below method is only to make sure we get jobs from incorrectly closed process (for example force killed using kill -9 SIDEKIQ_PID)
       def cleanup_the_dead
         overall_moved_count = 0
         Sidekiq.redis do |conn|
-          conn.sscan_each("super_processes_priority") do |super_process|
+          conn.sscan_each(SUPER_PROCESSES_REGISTRY_KEY) do |super_process|
             next if conn.exists?(super_process) # Don't clean up currently running processes
 
             Sidekiq.logger.debug { "Priority ReliableFetch: Moving job from #{super_process} back to original queues" }
@@ -118,7 +185,7 @@ module Sidekiq
 
               Sidekiq.logger.debug { "Priority ReliableFetch: Moving job from #{previously_handled_queue} back to original queue: #{original_priority_queue_name}" }
               loop do
-                break if conn.scard(previously_handled_queue) == 0
+                break if conn.scard(previously_handled_queue).zero?
 
                 # Here we should wrap below two operations in Lua script
                 item = conn.spop(previously_handled_queue)
@@ -127,19 +194,19 @@ module Sidekiq
                 overall_moved_count += 1
               end
               # Below we simply remove old WIP queue
-              conn.del(previously_handled_queue) if conn.scard(previously_handled_queue) == 0
-              Sidekiq.logger.debug { "Priority ReliableFetch: Moved #{queue_moved_size} jobs from ##{previously_handled_queue} back to original_queue: #{original_priority_queue_name} "}
+              conn.del(previously_handled_queue) if conn.scard(previously_handled_queue).zero?
+              Sidekiq.logger.debug { "Priority ReliableFetch: Moved #{queue_moved_size} jobs from ##{previously_handled_queue} back to original_queue: #{original_priority_queue_name} " }
             end
 
             Sidekiq.logger.debug { "Priority ReliableFetch: Unregistering super process #{super_process}" }
             conn.del("#{super_process}:super_priority_queues")
-            conn.srem("super_processes_priority", super_process)
+            conn.srem(SUPER_PROCESSES_REGISTRY_KEY, super_process)
           end
         end
         Sidekiq.logger.debug { "Priority ReliableFetch: Moved overall #{overall_moved_count} jobs from WIP queues" }
-      rescue => ex
+      rescue StandardError => e
         # best effort, ignore Redis network errors
-        Sidekiq.logger.warn { "Priority ReliableFetch: Failed to requeue: #{ex.message}" }
+        Sidekiq.logger.warn { "Priority ReliableFetch: Failed to requeue: #{e.message}" }
       end
 
       def requeue_wip_jobs
@@ -149,22 +216,22 @@ module Sidekiq
             wip_queue_name = wip_queue(q)
             jobs_to_requeue[q] = []
 
-            while job = conn.spop(wip_queue_name) do
+            while job = conn.spop(wip_queue_name)
               jobs_to_requeue[q] << job
             end
           end
 
           conn.pipelined do
             jobs_to_requeue.each do |queue, jobs|
-              next if jobs.size == 0 # ZADD doesn't work with empty arrays
+              next if jobs.empty? # ZADD doesn't work with empty arrays
 
-              conn.zadd(queue, jobs.map {|j| [0, j] })
+              conn.zadd(queue, jobs.map { |j| [0, j] })
             end
           end
         end
-        Sidekiq.logger.info("Priority ReliableFetch: Pushed #{ jobs_to_requeue.values.flatten.size } jobs back to Redis")
-      rescue => ex
-        Sidekiq.logger.warn("Priority ReliableFetch: Failed to requeue #{ jobs_to_requeue.values.flatten.size } jobs: #{ex.message}")
+        Sidekiq.logger.info("Priority ReliableFetch: Pushed #{jobs_to_requeue.values.flatten.size} jobs back to Redis")
+      rescue StandardError => e
+        Sidekiq.logger.warn("Priority ReliableFetch: Failed to requeue #{jobs_to_requeue.values.flatten.size} jobs: #{e.message}")
       end
 
       def register_myself
@@ -176,7 +243,7 @@ module Sidekiq
 
         Sidekiq.redis do |conn|
           conn.multi do
-            conn.sadd("super_processes_priority", id)
+            conn.sadd(SUPER_PROCESSES_REGISTRY_KEY, id)
             conn.sadd("#{id}:super_priority_queues", super_process_wip_queues)
           end
         end
@@ -187,7 +254,7 @@ module Sidekiq
         Sidekiq.logger.debug { "Priority ReliableFetch: Unregistering super process #{id}" }
         Sidekiq.redis do |conn|
           conn.multi do
-            conn.srem("super_processes_priority", id)
+            conn.srem(SUPER_PROCESSES_REGISTRY_KEY, id)
             conn.del("#{id}:super_priority_queues")
           end
         end

--- a/lib/sidekiq/priority_queue/reliable_fetch.rb
+++ b/lib/sidekiq/priority_queue/reliable_fetch.rb
@@ -113,7 +113,7 @@ module Sidekiq
       end
 
       def orphan_check?
-        delay = @options.fetch(:super_fetch_orphan_check, 3600).to_i
+        delay = @options.fetch(:reliable_fetch_orphan_check, 3600).to_i
         return false if delay.zero?
 
         Sidekiq.redis do |conn|

--- a/sidekiq-priority_queue.gemspec
+++ b/sidekiq-priority_queue.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'sidekiq-priority_queue'
-  s.version     = '1.0.5'
+  s.version     = '1.0.6'
   s.date        = '2018-07-31'
   s.summary     = "Priority Queuing for Sidekiq"
   s.description = "An extension for Sidekiq allowing jobs in a single queue to be executed by a priority score rather than FIFO"


### PR DESCRIPTION
Related issue: https://app.shortcut.com/chartmogul/story/37849/implement-orphan-check-for-sidekiq-priority-queue

This implements orphan check to make sure that we, somehow, still have old stuff laying around, we will be able to retrieve that stuff and put it back into the queues.